### PR TITLE
Empty constructor removed

### DIFF
--- a/src/main/java/org/apache/commons/dbutils/GenerousBeanProcessor.java
+++ b/src/main/java/org/apache/commons/dbutils/GenerousBeanProcessor.java
@@ -28,13 +28,7 @@ import java.util.Arrays;
  * @since 1.6
  */
 public class GenerousBeanProcessor extends BeanProcessor {
-
-    /**
-     * Default constructor.
-     */
-    public GenerousBeanProcessor() {
-    }
-
+    
     @Override
     protected int[] mapColumnsToProperties(final ResultSetMetaData rsmd,
             final PropertyDescriptor[] props) throws SQLException {

--- a/src/test/java/org/apache/commons/dbutils/TestBean.java
+++ b/src/test/java/org/apache/commons/dbutils/TestBean.java
@@ -61,12 +61,6 @@ public class TestBean {
      */
     private double columnProcessorDoubleTest = -1;
 
-    /**
-     * Constructor for TestBean.
-     */
-    public TestBean() {
-    }
-
     public double getColumnProcessorDoubleTest() {
         return columnProcessorDoubleTest;
     }


### PR DESCRIPTION
both removed default constructor do not differ from the implicitely generated default constructors, so could be removed.
tests for both classes were successfull (but mvn test not run)